### PR TITLE
Add systemless kernel module packaging via Magisk/KSU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ toolchains/clang
 clang.tar.gz
 firmware
 builds
+sm7325-klm*

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ toolchains/clang
 clang.tar.gz
 firmware
 builds
-sm7325-klm*
+sm7325-*

--- a/README.md
+++ b/README.md
@@ -165,3 +165,29 @@ Navigate to the output directory containing the compiled files for the variant y
     ```
 
 After the flash is complete, your device should reboot automatically with the new custom kernel.
+
+### Installing Kernel Modules (The Systemless Way)
+
+Instead of permanently writing to your device's partitions, the kernel modules are now packaged as a separate, systemless Magisk/KernelSU module. This is the modern, recommended approach as it is significantly safer and more flexible.
+
+**Key Advantages:**
+
+*   **Systemless:** Your `/vendor` partition is never modified directly. The modules are loaded as an overlay during boot.
+*   **Safe & Easy:** You can easily disable or uninstall the modules from the Magisk/KernelSU app without needing to re-flash your stock firmware.
+*   **Smart Fixes:** The module is intelligent. For example, it automatically detects if you are on an A52s and applies a necessary camera fix systemlessly. This fix is skipped on other devices.
+
+**Installation Steps:**
+
+1.  **Flash the Kernel First:** Ensure you have already flashed the main kernel images (`boot.img`, `vbmeta.img`, etc.) using the Heimdall method described in the previous section. Your device should be booted into Android.
+
+2.  **Locate the Module ZIP:** After running the `./pack_modules.sh` script in the `kernel-build` directory, you will find a ZIP file named something like `sm7325-klm-1.1-20250815.zip`.
+
+3.  **Transfer to Your Phone:** Copy this ZIP file to your phone's internal storage or SD card.
+
+4.  **Install via App:**
+    *   Open the **Magisk** or **KernelSU** application on your phone.
+    *   Navigate to the **Modules** section.
+    *   Tap the **Install from storage** button.
+    *   Find and select the module ZIP file you just copied.
+
+5.  **Reboot:** Once the in-app installation is complete, reboot your device. The new kernel modules and any applicable fixes will now be active.

--- a/pack_modules.sh
+++ b/pack_modules.sh
@@ -1,33 +1,32 @@
 #!/bin/bash
 #
-# KLM to Magisk/KSU Module Packager
+# Final Magisk/KSU Systemless Module Packager
 # Coded by JingMatrix @2025
 #
-# This script takes the compiled kernel modules from a kernel build
-# and packages them into a flashable Magisk/KernelSU module ZIP.
-# It also includes device-specific fixes in the installer.
+# This script packages the compiled kernel modules and the
+# vendor_modprobe.sh helper into a clean, systemless module.
 #
 
 set -e
 
 # --- Module Configuration ---
-MODULE_ID="sm7325-klm"
-MODULE_NAME="Kernel Modules for SM7325"
-MODULE_VERSION="1.1-$(date +%Y%m%d)" # Version incremented for new feature
+MODULE_ID="sm7325-kernel-module-pack"
+MODULE_NAME="Kernel Module Pack for SM7325"
+MODULE_VERSION="1.0-$(date +%Y%m%d)"
 MODULE_AUTHOR="JingMatrix"
-MODULE_DESC="Installs kernel modules and applies camera fix for the Galaxy A52s."
+MODULE_DESC="Systemless installation of kernel modules and the vendor_modprobe.sh helper."
 
 # --- Path Configuration ---
 # Assumes this script is in `kernel-build` and builds are in `builds`
 BUILDS_DIR="$(pwd)/builds"
-MODULE_WORK_DIR="$(pwd)/module_temp"
-# Path to your custom modprobe helper script
+MODULE_WORK_DIR="$(pwd)/module_temp_final"
+# The script will look for this file in the current directory (`kernel-build`)
 MODPROBE_SOURCE_SCRIPT="vendor_modprobe.sh"
 
 # --- Script Logic (DO NOT EDIT BELOW THIS LINE) ---
 
 echo "=============================================="
-echo "Magisk/KSU Module Packager"
+echo "Final Systemless Module Packager"
 echo "=============================================="
 
 # 1. Find the latest built variant to source modules from.
@@ -37,10 +36,10 @@ if [ ! -d "$BUILDS_DIR" ] || [ -z "$(ls -A "$BUILDS_DIR")" ]; then
     exit 1
 fi
 LATEST_VARIANT_PATH=$(ls -td -- "$BUILDS_DIR"/*/ | head -n 1)
-SOURCE_MODULES_DIR="${LATEST_VARIANT_PATH}modules"
+SOURCE_MODULES_DIR="${LATEST_VARIANT_PATH}modules/vendor/lib/modules"
 
 if [ ! -d "$SOURCE_MODULES_DIR" ]; then
-    echo "ERROR: Could not find a 'modules' directory in the latest build: $LATEST_VARIANT_PATH"
+    echo "ERROR: Could not find the final 'modules' directory in: $LATEST_VARIANT_PATH"
     exit 1
 fi
 echo "Found modules to package from: $(basename "$LATEST_VARIANT_PATH")"
@@ -53,7 +52,7 @@ rm -f "$FINAL_ZIP_NAME"
 
 echo "Creating module structure..."
 MODULE_SYSTEM_DIR="$MODULE_WORK_DIR/system"
-mkdir -p "$MODULE_SYSTEM_DIR"
+mkdir -p "$MODULE_SYSTEM_DIR/vendor/lib/modules"
 mkdir -p "$MODULE_WORK_DIR/META-INF/com/google/android"
 
 # 3. Create the Magisk/KSU metadata files.
@@ -70,8 +69,8 @@ description=$MODULE_DESC
 reboot=true
 EOF
 
-# Create customize.sh - This is the new installer logic.
-echo "Creating customize.sh with camera fix..."
+# Create customize.sh with the final permission-setting logic.
+echo "Creating final customize.sh..."
 cat <<'EOF' > "$MODULE_WORK_DIR/customize.sh"
 #!/system/bin/sh
 # This script is executed by the Magisk/KernelSU installer environment.
@@ -85,79 +84,56 @@ if [ -z "$MODPATH" ]; then
   abort
 fi
 
-# Set permissions for modules and scripts first.
-ui_print "- Setting base permissions..."
+ui_print "*********************************************************"
+ui_print "*      Installing Systemless Kernel Module Pack         *"
+ui_print "*********************************************************"
+ui_print "- Setting permissions..."
+
+# Set permissions for the directory containing all the kernel modules
 set_perm_recursive $MODPATH/system/vendor/lib/modules 0 2000 0755 0644 u:object_r:vendor_file:s0
+ui_print "  - Kernel module permissions set."
+
+# Check for the vendor_modprobe.sh helper and set its permissions
 MODPROBE_HELPER=$MODPATH/system/vendor/bin/vendor_modprobe.sh
 if [ -f "$MODPROBE_HELPER" ]; then
+  # This sets owner 0 (root), group 2000 (shell), permissions 755 (rwxr-xr-x),
+  # and the correct SELinux context for an executable in /vendor/bin.
   set_perm $MODPROBE_HELPER 0 2000 0755 u:object_r:vendor_modinstall-sh_exec:s0
-fi
-
-# --- Device Specific Fixes ---
-# Credits to ddavidavidd @Telegram for the camera fix method.
-
-DEVICE=$(getprop ro.product.device)
-if [[ "$DEVICE" == "a52s" || "$DEVICE" == "a52sxq" ]]; then
-  ui_print "- Device is A52s, checking for camera fix..."
-  CAMERA_LIB="/vendor/lib64/hw/camera.qcom.so"
-  
-  if [ -f "$CAMERA_LIB" ] && grep -q "ro.boot.flash.locked" "$CAMERA_LIB"; then
-    ui_print "- Applying camera library patch..."
-    
-    # Create the directory structure within the module
-    mkdir -p "$MODPATH/system/vendor/lib64/hw"
-    
-    # Use sed to patch the library and place the MODIFIED version in the module directory.
-    # This leaves the original file untouched on the /vendor partition.
-    sed 's/ro.boot.flash.locked/ro.camera.notify_nfc/g' "$CAMERA_LIB" > "$MODPATH$CAMERA_LIB"
-    
-    # Set the correct permissions and context on the NEW file inside the module.
-    set_perm "$MODPATH$CAMERA_LIB" 0 0 0644 u:object_r:vendor_file:s0
-    ui_print "- Camera fix applied systemlessly."
-  else
-    ui_print "- Camera library does not require patching."
-  fi
-else
-  ui_print "- Not an A52s, skipping camera fix."
+  ui_print "  - vendor_modprobe.sh permissions set."
 fi
 
 ui_print "- Installation complete."
-
 EOF
 
 # Create the standard, minimal META-INF scripts
 echo "Creating standard META-INF scripts..."
 cat <<EOF > "$MODULE_WORK_DIR/META-INF/com/google/android/updater-script"
 # Magisk/KSU stub
-# Real installation logic is in customize.sh
 EOF
-
 cat <<EOF > "$MODULE_WORK_DIR/META-INF/com/google/android/update-binary"
 #!/sbin/sh
-# Magisk/KSU Installer stub
 OUTFD=\$2
 ZIPFILE=\$3
 . /data/adb/magisk/util_functions.sh
 . \$ZIPFILE/customize.sh
 exit 0
 EOF
-
 chmod 755 "$MODULE_WORK_DIR/META-INF/com/google/android/update-binary"
 
-# 4. Copy the kernel modules and helper scripts into the structure.
+# 4. Copy the kernel modules and helper script into the module structure.
 echo "Copying kernel modules..."
-cp -r "$SOURCE_MODULES_DIR"/* "$MODULE_SYSTEM_DIR/"
+cp -r "$SOURCE_MODULES_DIR"/* "$MODULE_SYSTEM_DIR/vendor/lib/modules/"
 
 if [ -f "$MODPROBE_SOURCE_SCRIPT" ]; then
     echo "Copying vendor_modprobe.sh..."
     mkdir -p "$MODULE_SYSTEM_DIR/vendor/bin"
     cp "$MODPROBE_SOURCE_SCRIPT" "$MODULE_SYSTEM_DIR/vendor/bin/"
 else
-    echo "WARNING: vendor_modprobe.sh not found, skipping."
+    echo "WARNING: vendor_modprobe.sh not found in current directory, skipping."
 fi
 
 # 5. Package everything into a ZIP file.
-echo "Creating flashable ZIP: $FINAL_ZIP_NAME..."
+echo "Creating final flashable ZIP: $FINAL_ZIP_NAME..."
 cd "$MODULE_WORK_DIR"
 zip -r9 "../$FINAL_ZIP_NAME" ./*
 cd ..
@@ -166,7 +142,6 @@ cd ..
 rm -rf "$MODULE_WORK_DIR"
 
 echo "=============================================="
-echo "Successfully created module:"
+echo "Successfully created final systemless module:"
 echo "$FINAL_ZIP_NAME"
-echo "You can now flash this file using the Magisk or KernelSU app."
 echo "=============================================="

--- a/pack_modules.sh
+++ b/pack_modules.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+#
+# KLM to Magisk/KSU Module Packager
+# Coded by JingMatrix @2025
+#
+# This script takes the compiled kernel modules from a kernel build
+# and packages them into a flashable Magisk/KernelSU module ZIP.
+# It also includes device-specific fixes in the installer.
+#
+
+set -e
+
+# --- Module Configuration ---
+MODULE_ID="sm7325-klm"
+MODULE_NAME="Kernel Modules for SM7325"
+MODULE_VERSION="1.1-$(date +%Y%m%d)" # Version incremented for new feature
+MODULE_AUTHOR="JingMatrix"
+MODULE_DESC="Installs kernel modules and applies camera fix for the Galaxy A52s."
+
+# --- Path Configuration ---
+# Assumes this script is in `kernel-build` and builds are in `builds`
+BUILDS_DIR="$(pwd)/builds"
+MODULE_WORK_DIR="$(pwd)/module_temp"
+# Path to your custom modprobe helper script
+MODPROBE_SOURCE_SCRIPT="vendor_modprobe.sh"
+
+# --- Script Logic (DO NOT EDIT BELOW THIS LINE) ---
+
+echo "=============================================="
+echo "Magisk/KSU Module Packager"
+echo "=============================================="
+
+# 1. Find the latest built variant to source modules from.
+if [ ! -d "$BUILDS_DIR" ] || [ -z "$(ls -A "$BUILDS_DIR")" ]; then
+    echo "ERROR: Output directory '$BUILDS_DIR' is empty or does not exist."
+    echo "Please run the main kernel build script first."
+    exit 1
+fi
+LATEST_VARIANT_PATH=$(ls -td -- "$BUILDS_DIR"/*/ | head -n 1)
+SOURCE_MODULES_DIR="${LATEST_VARIANT_PATH}modules"
+
+if [ ! -d "$SOURCE_MODULES_DIR" ]; then
+    echo "ERROR: Could not find a 'modules' directory in the latest build: $LATEST_VARIANT_PATH"
+    exit 1
+fi
+echo "Found modules to package from: $(basename "$LATEST_VARIANT_PATH")"
+
+# 2. Clean up and create the working directory structure.
+FINAL_ZIP_NAME="${MODULE_ID}-${MODULE_VERSION}.zip"
+echo "Cleaning up previous build..."
+rm -rf "$MODULE_WORK_DIR"
+rm -f "$FINAL_ZIP_NAME"
+
+echo "Creating module structure..."
+MODULE_SYSTEM_DIR="$MODULE_WORK_DIR/system"
+mkdir -p "$MODULE_SYSTEM_DIR"
+mkdir -p "$MODULE_WORK_DIR/META-INF/com/google/android"
+
+# 3. Create the Magisk/KSU metadata files.
+
+# Create module.prop
+echo "Creating module.prop..."
+cat <<EOF > "$MODULE_WORK_DIR/module.prop"
+id=$MODULE_ID
+name=$MODULE_NAME
+version=$MODULE_VERSION
+versionCode=$(date +%Y%m%d)
+author=$MODULE_AUTHOR
+description=$MODULE_DESC
+reboot=true
+EOF
+
+# Create customize.sh - This is the new installer logic.
+echo "Creating customize.sh with camera fix..."
+cat <<'EOF' > "$MODULE_WORK_DIR/customize.sh"
+#!/system/bin/sh
+# This script is executed by the Magisk/KernelSU installer environment.
+
+# Abort installation if the user tries to flash this in recovery.
+if [ -z "$MODPATH" ]; then
+  ui_print "*********************************************************"
+  ui_print "! This is a Magisk/KernelSU module, not a recovery ZIP."
+  ui_print "! Please install it from the Magisk or KernelSU app."
+  ui_print "*********************************************************"
+  abort
+fi
+
+# Set permissions for modules and scripts first.
+ui_print "- Setting base permissions..."
+set_perm_recursive $MODPATH/system/vendor/lib/modules 0 2000 0755 0644 u:object_r:vendor_file:s0
+MODPROBE_HELPER=$MODPATH/system/vendor/bin/vendor_modprobe.sh
+if [ -f "$MODPROBE_HELPER" ]; then
+  set_perm $MODPROBE_HELPER 0 2000 0755 u:object_r:vendor_modinstall-sh_exec:s0
+fi
+
+# --- Device Specific Fixes ---
+# Credits to ddavidavidd @Telegram for the camera fix method.
+
+DEVICE=$(getprop ro.product.device)
+if [[ "$DEVICE" == "a52s" || "$DEVICE" == "a52sxq" ]]; then
+  ui_print "- Device is A52s, checking for camera fix..."
+  CAMERA_LIB="/vendor/lib64/hw/camera.qcom.so"
+  
+  if [ -f "$CAMERA_LIB" ] && grep -q "ro.boot.flash.locked" "$CAMERA_LIB"; then
+    ui_print "- Applying camera library patch..."
+    
+    # Create the directory structure within the module
+    mkdir -p "$MODPATH/system/vendor/lib64/hw"
+    
+    # Use sed to patch the library and place the MODIFIED version in the module directory.
+    # This leaves the original file untouched on the /vendor partition.
+    sed 's/ro.boot.flash.locked/ro.camera.notify_nfc/g' "$CAMERA_LIB" > "$MODPATH$CAMERA_LIB"
+    
+    # Set the correct permissions and context on the NEW file inside the module.
+    set_perm "$MODPATH$CAMERA_LIB" 0 0 0644 u:object_r:vendor_file:s0
+    ui_print "- Camera fix applied systemlessly."
+  else
+    ui_print "- Camera library does not require patching."
+  fi
+else
+  ui_print "- Not an A52s, skipping camera fix."
+fi
+
+ui_print "- Installation complete."
+
+EOF
+
+# Create the standard, minimal META-INF scripts
+echo "Creating standard META-INF scripts..."
+cat <<EOF > "$MODULE_WORK_DIR/META-INF/com/google/android/updater-script"
+# Magisk/KSU stub
+# Real installation logic is in customize.sh
+EOF
+
+cat <<EOF > "$MODULE_WORK_DIR/META-INF/com/google/android/update-binary"
+#!/sbin/sh
+# Magisk/KSU Installer stub
+OUTFD=\$2
+ZIPFILE=\$3
+. /data/adb/magisk/util_functions.sh
+. \$ZIPFILE/customize.sh
+exit 0
+EOF
+
+chmod 755 "$MODULE_WORK_DIR/META-INF/com/google/android/update-binary"
+
+# 4. Copy the kernel modules and helper scripts into the structure.
+echo "Copying kernel modules..."
+cp -r "$SOURCE_MODULES_DIR"/* "$MODULE_SYSTEM_DIR/"
+
+if [ -f "$MODPROBE_SOURCE_SCRIPT" ]; then
+    echo "Copying vendor_modprobe.sh..."
+    mkdir -p "$MODULE_SYSTEM_DIR/vendor/bin"
+    cp "$MODPROBE_SOURCE_SCRIPT" "$MODULE_SYSTEM_DIR/vendor/bin/"
+else
+    echo "WARNING: vendor_modprobe.sh not found, skipping."
+fi
+
+# 5. Package everything into a ZIP file.
+echo "Creating flashable ZIP: $FINAL_ZIP_NAME..."
+cd "$MODULE_WORK_DIR"
+zip -r9 "../$FINAL_ZIP_NAME" ./*
+cd ..
+
+# 6. Final cleanup.
+rm -rf "$MODULE_WORK_DIR"
+
+echo "=============================================="
+echo "Successfully created module:"
+echo "$FINAL_ZIP_NAME"
+echo "You can now flash this file using the Magisk or KernelSU app."
+echo "=============================================="

--- a/vendor_modprobe.sh
+++ b/vendor_modprobe.sh
@@ -1,0 +1,19 @@
+#! /vendor/bin/sh
+#=============================================================================
+# Copyright (c) 2019-2020 Qualcomm Technologies, Inc.
+# All Rights Reserved.
+# Confidential and Proprietary - Qualcomm Technologies, Inc.
+#=============================================================================
+
+MODULES_PATH="/vendor/lib/modules/"
+
+MODPROBE="/vendor/bin/modprobe"
+MODULES=`${MODPROBE} -d ${MODULES_PATH} -l`
+
+# Iterate over module list and modprobe them in background.
+for MODULE in ${MODULES}; do
+	${MODPROBE} -a -b -d ${MODULES_PATH} ${MODULE} &
+done
+
+# Wait until all the modprobes are finished
+wait


### PR DESCRIPTION
A new `pack_modules.sh` script is added to the build system. This script automatically creates a flashable Magisk/KernelSU module ZIP that contains all necessary kernel modules (`.ko` files) and installer logic.