### PR TITLE
Add systemless camera fix for A52s

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ However, using `--flags 2` creates a new problem: the bootloader sees verificati
 The helper module serves two critical functions:
 
 1.  **Systemless Module Loading:** Its primary job is to package all the necessary kernel modules (`.ko` driver files) into a safe, systemless module. This means your `/vendor` partition is never modified.
-2.  **Runtime Property Injection:** The `service.sh` script within the helper module is specifically designed to fix the problem created by the bootable `vbmeta`. It runs at boot and uses `resetprop` to **add the missing `ro.boot.vbmeta.*` properties back into the system**. By providing these properties, it spoofs a clean, stock boot environment and provides the necessary foundation for passing integrity checks.
+2.  **A52s Camera Fix:** The module automatically detects if it is being installed on a Galaxy A52s and applies a systemless patch to the camera libraries. This fixes the common "camera crash" issue that occurs on devices with an unlocked bootloader.
+3.  **Runtime Property Injection:** The `service.sh` script within the helper module is specifically designed to fix the problem created by the bootable `vbmeta`. It runs at boot and uses `resetprop` to **add the missing `ro.boot.vbmeta.*` properties back into the system**. By providing these properties, it spoofs a clean, stock boot environment and provides the necessary foundation for passing integrity checks.
 
 ---
 

--- a/pack_modules.sh
+++ b/pack_modules.sh
@@ -3,79 +3,249 @@
 # Magisk/KSU Systemless Module Packager
 # Coded by JingMatrix @2025
 #
-# This script packages compiled kernel modules and a helper script
-# into a clean, systemless "Kernel Helper" module.
+# This script packages compiled kernel modules and helper scripts
+# into a clean, systemless "Kernel Helper" module using a highly
+# modular, function-based design.
+#
+# SCRIPT ARCHITECTURE:
+# 1. Setup Functions: Prepare the environment and calculate dynamic values.
+# 2. Core Feature Functions: Self-contained functions that each package one
+#    major feature (e.g., KLM Loading, Camera Fix).
+# 3. Main Execution: A main() function that orchestrates the entire process.
 #
 
 set -e
 
-# --- Module Configuration ---
+# --- Configuration ---
 MODULE_ID="sm7325-kernel-helper"
 MODULE_NAME="Kernel Helper Pack for SM7325"
-MODULE_VERSION="2.1-$(date +%Y%m%d)"
+MODULE_VERSION="3.5-$(date +%Y%m%d)"
 MODULE_AUTHOR="JingMatrix"
-MODULE_DESC="Systemlessly installs kernel modules and spoofs boot properties to pass integrity checks."
+MODULE_DESC="Systemlessly installs kernel modules, applies runtime fixes, and spoofs boot properties."
 
 # --- Path Configuration ---
-# Assumes this script is in the main project dir and builds are in `builds`
 BUILDS_DIR="$(pwd)/builds"
 MODULE_WORK_DIR="$(pwd)/module_temp_work"
-# The script will look for this file in the current directory
 MODPROBE_SOURCE_SCRIPT="vendor_modprobe.sh"
-
-# --- Script Logic (DO NOT EDIT BELOW THIS LINE) ---
-
-echo "=============================================="
-echo "Systemless Module Packager"
-echo "=============================================="
-
-# 1. Find the latest built variant to source modules and vbmeta from.
-if [ ! -d "$BUILDS_DIR" ] || [ -z "$(ls -A "$BUILDS_DIR")" ]; then
-    echo "ERROR: Output directory '$BUILDS_DIR' is empty or does not exist."
-    echo "Please run the main kernel build script first."
-    exit 1
-fi
-LATEST_VARIANT_PATH=$(ls -td -- "$BUILDS_DIR"/*/ | head -n 1)
-SOURCE_MODULES_DIR="${LATEST_VARIANT_PATH}modules/vendor/lib/modules"
-SOURCE_VBMETA_PATH="${LATEST_VARIANT_PATH}vbmeta.img"
-
-if [ ! -d "$SOURCE_MODULES_DIR" ]; then
-    echo "ERROR: Could not find the 'modules' directory in: $LATEST_VARIANT_PATH"
-    exit 1
-fi
-echo "Found modules to package from: $(basename "$LATEST_VARIANT_PATH")"
-
-# 2. Dynamically calculate the vbmeta digest and size for spoofing.
-if [ ! -f "$SOURCE_VBMETA_PATH" ]; then
-    echo "ERROR: Could not find vbmeta.img in '$LATEST_VARIANT_PATH' to calculate digest."
-    exit 1
-fi
-VBMETA_DIGEST=$(sha256sum "$SOURCE_VBMETA_PATH" | awk '{print $1}')
-VBMETA_SIZE=$(stat -c %s "$SOURCE_VBMETA_PATH")
-
-if [ -z "$VBMETA_DIGEST" ] || [ -z "$VBMETA_SIZE" ]; then
-    echo "ERROR: Failed to calculate digest or size of vbmeta.img."
-    exit 1
-fi
-echo "Determined vbmeta digest for spoofing: ${VBMETA_DIGEST}"
-echo "Determined vbmeta size for spoofing: ${VBMETA_SIZE}"
-
-# 3. Clean up and create the working directory structure.
 MODULE_ZIP_NAME="${MODULE_ID}-${MODULE_VERSION}.zip"
-echo "Cleaning up previous build..."
-rm -rf "$MODULE_WORK_DIR"
-rm -f "$MODULE_ZIP_NAME"
 
-echo "Creating module structure..."
-MODULE_SYSTEM_DIR="$MODULE_WORK_DIR/system"
-mkdir -p "$MODULE_SYSTEM_DIR/vendor/lib/modules"
-mkdir -p "$MODULE_WORK_DIR/META-INF/com/google/android"
+# --- Global Variables (set by setup functions) ---
+LATEST_VARIANT_PATH=""
+SOURCE_MODULES_DIR=""
+SOURCE_VBMETA_PATH=""
+VBMETA_DIGEST=""
+VBMETA_SIZE=""
+CUSTOMIZE_SH_PATH=""
 
-# 4. Create the Magisk/KSU metadata files.
 
-# Create module.prop
-echo "Creating module.prop..."
-cat <<EOF > "$MODULE_WORK_DIR/module.prop"
+# =============================================================================
+# === 1. SETUP AND UTILITY FUNCTIONS
+# =============================================================================
+
+# Finds the latest build output directory to source files from.
+find_latest_build() {
+    echo "Finding the latest build output..."
+    if [ ! -d "$BUILDS_DIR" ] || [ -z "$(ls -A "$BUILDS_DIR")" ]; then
+        echo "ERROR: Output directory '$BUILDS_DIR' is empty or does not exist." >&2
+        exit 1
+    fi
+    LATEST_VARIANT_PATH=$(ls -td -- "$BUILDS_DIR"/*/ | head -n 1)
+    SOURCE_MODULES_DIR="${LATEST_VARIANT_PATH}modules"
+    SOURCE_VBMETA_PATH="${LATEST_VARIANT_PATH}vbmeta.img"
+
+    if [ ! -d "$SOURCE_MODULES_DIR" ]; then
+        echo "ERROR: Could not find the 'modules' directory in: $LATEST_VARIANT_PATH" >&2
+        exit 1
+    fi
+    echo "Source build for packaging: $(basename "$LATEST_VARIANT_PATH")"
+}
+
+# Calculates the digest and size of the vbmeta.img for spoofing.
+calculate_vbmeta_props() {
+    echo "Calculating vbmeta properties for spoofing..."
+    if [ ! -f "$SOURCE_VBMETA_PATH" ]; then
+        echo "ERROR: Could not find vbmeta.img in '$LATEST_VARIANT_PATH'." >&2
+        exit 1
+    fi
+    VBMETA_DIGEST=$(sha256sum "$SOURCE_VBMETA_PATH" | awk '{print $1}')
+    VBMETA_SIZE=$(stat -c %s "$SOURCE_VBMETA_PATH")
+
+    if [ -z "$VBMETA_DIGEST" ] || [ -z "$VBMETA_SIZE" ]; then
+        echo "ERROR: Failed to calculate digest or size of vbmeta.img." >&2
+        exit 1
+    fi
+    echo "Determined vbmeta digest: ${VBMETA_DIGEST}"
+    echo "Determined vbmeta size: ${VBMETA_SIZE}"
+}
+
+# Cleans up old artifacts and creates the base directory structure.
+create_base_module_structure() {
+    echo "Creating base module structure..."
+    rm -rf "$MODULE_WORK_DIR"
+    rm -f "$MODULE_ZIP_NAME"
+    mkdir -p "$MODULE_WORK_DIR/system"
+    mkdir -p "$MODULE_WORK_DIR/META-INF/com/google/android"
+    CUSTOMIZE_SH_PATH="$MODULE_WORK_DIR/customize.sh"
+}
+
+# =============================================================================
+# === 2. CORE FEATURE PACKAGING FUNCTIONS
+# =============================================================================
+
+# Packages the Kernel Loadable Modules (KLM) and the modprobe helper.
+build_feature_klm_loading() {
+    echo "Packaging Feature: Kernel Module Loading"
+
+    # --- Step 1: Copy module content ---
+    echo "  -> Copying kernel modules..."
+    mkdir -p "$MODULE_WORK_DIR/system"
+    cp -a "$SOURCE_MODULES_DIR/vendor" "$MODULE_WORK_DIR/system/"
+
+    if [ -f "$MODPROBE_SOURCE_SCRIPT" ]; then
+        echo "  -> Copying vendor_modprobe.sh..."
+        mkdir -p "$MODULE_WORK_DIR/system/vendor/bin"
+        cp "$MODPROBE_SOURCE_SCRIPT" "$MODULE_WORK_DIR/system/vendor/bin/"
+    else
+        echo "  -> WARNING: vendor_modprobe.sh not found, skipping."
+    fi
+
+    # --- Step 2: Append installation logic to customize.sh ---
+    cat <<'EOF' >> "$CUSTOMIZE_SH_PATH"
+
+ui_print "- Setting Kernel Module Loading permissions..."
+set_perm_recursive $MODPATH/system/vendor/lib/modules 0 2000 0755 0644 u:object_r:vendor_file:s0
+MODPROBE_HELPER=$MODPATH/system/vendor/bin/vendor_modprobe.sh
+if [ -f "$MODPROBE_HELPER" ]; then
+  set_perm $MODPROBE_HELPER 0 2000 0755 u:object_r:vendor_modinstall-sh_exec:s0
+  ui_print "  - Permissions set for kernel modules and modprobe helper."
+else
+  ui_print "  - Permissions set for kernel modules."
+fi
+EOF
+}
+
+# Packages the service.sh script to spoof VBMeta properties.
+build_feature_vbmeta_spoof() {
+    echo "Packaging Feature: VBMeta Property Spoofing"
+
+    # --- Create the service.sh file with dynamic property values ---
+    cat <<EOF > "$MODULE_WORK_DIR/service.sh"
+#!/system/bin/sh
+# Executed by Magisk/KernelSU to spoof vbmeta properties.
+sleep 15
+resetprop -n ro.boot.vbmeta.avb_version 1.0
+resetprop -n ro.boot.vbmeta.device_state locked
+resetprop -n ro.boot.vbmeta.digest ${VBMETA_DIGEST}
+resetprop -n ro.boot.vbmeta.hash_alg sha256
+resetprop -n ro.boot.vbmeta.invalidate_on_error yes
+resetprop -n ro.boot.vbmeta.size ${VBMETA_SIZE}
+resetprop -n ro.boot.verifiedbootstate green
+log -p i -t KernelHelper "Successfully spoofed boot properties."
+EOF
+    chmod 755 "$MODULE_WORK_DIR/service.sh"
+}
+
+# Appends the A52s camera fix logic to the customize.sh script.
+build_feature_camera_fix() {
+    echo "Packaging Feature: A52s Camera Fix"
+
+    # --- Append the robust, verbose camera fix logic to customize.sh ---
+    cat <<'EOF' >> "$CUSTOMIZE_SH_PATH"
+
+ui_print "- Checking for A52s camera fix..."
+DEVICE_CODENAME=$(getprop ro.product.device)
+if [[ "$DEVICE_CODENAME" == "a52s"* ]]; then
+    ui_print "  - Device identified as Galaxy A52s ($DEVICE_CODENAME)."
+    ui_print "  - Checking camera libraries for required patches..."
+
+    PATCH_APPLIED=false
+
+    # Create the necessary directories once to avoid repetition.
+    mkdir -p "$MODPATH/system/vendor/lib/hw"
+    mkdir -p "$MODPATH/system/vendor/lib64/hw"
+
+    set_perm_recursive $MODPATH/system/vendor/lib 0 2000 0755 0644 u:object_r:vendor_file:s0
+    set_perm_recursive $MODPATH/system/vendor/lib64 0 2000 0755 0644 u:object_r:vendor_file:s0
+    ui_print "  - Set base permissions for vendor/lib and vendor/lib64."
+    # --- Check, patch, and set permissions for each library individually ---
+
+    # 64-bit main library
+    if [ -f "/vendor/lib64/hw/camera.qcom.so" ]; then
+        if grep -q 'ro.boot.flash.locked' /vendor/lib64/hw/camera.qcom.so; then
+            ui_print "    - Patching /vendor/lib64/hw/camera.qcom.so..."
+            sed 's/ro.boot.flash.locked/ro.camera.notify_nfc/g' "/vendor/lib64/hw/camera.qcom.so" > "$MODPATH/system/vendor/lib64/hw/camera.qcom.so"
+            set_perm "$MODPATH/system/vendor/lib64/hw/camera.qcom.so" 0 0 0644 u:object_r:vendor_file:s0
+            PATCH_APPLIED=true
+        else
+            ui_print "    - Skipping /vendor/lib64/hw/camera.qcom.so (no patch needed)."
+        fi
+    fi
+
+    # 64-bit override library
+    if [ -f "/vendor/lib64/hw/com.qti.chi.override.so" ]; then
+        if grep -q 'ro.boot.flash.locked' /vendor/lib64/hw/com.qti.chi.override.so; then
+            ui_print "    - Patching /vendor/lib64/hw/com.qti.chi.override.so..."
+            sed 's/ro.boot.flash.locked/ro.camera.notify_nfc/g' "/vendor/lib64/hw/com.qti.chi.override.so" > "$MODPATH/system/vendor/lib64/hw/com.qti.chi.override.so"
+            set_perm "$MODPATH/system/vendor/lib64/hw/com.qti.chi.override.so" 0 0 0644 u:object_r:vendor_file:s0
+            PATCH_APPLIED=true
+        else
+            ui_print "    - Skipping /vendor/lib64/hw/com.qti.chi.override.so (no patch needed)."
+        fi
+    fi
+
+    # 32-bit main library
+    if [ -f "/vendor/lib/hw/camera.qcom.so" ]; then
+        if grep -q 'ro.boot.flash.locked' /vendor/lib/hw/camera.qcom.so; then
+            ui_print "    - Patching /vendor/lib/hw/camera.qcom.so..."
+            sed 's/ro.boot.flash.locked/ro.camera.notify_nfc/g' "/vendor/lib/hw/camera.qcom.so" > "$MODPATH/system/vendor/lib/hw/camera.qcom.so"
+            set_perm "$MODPATH/system/vendor/lib/hw/camera.qcom.so" 0 0 0644 u:object_r:vendor_file:s0
+            PATCH_APPLIED=true
+        else
+            ui_print "    - Skipping /vendor/lib/hw/camera.qcom.so (no patch needed)."
+        fi
+    fi
+
+    # 32-bit override library
+    if [ -f "/vendor/lib/hw/com.qti.chi.override.so" ]; then
+        if grep -q 'ro.boot.flash.locked' /vendor/lib/hw/com.qti.chi.override.so; then
+            ui_print "    - Patching /vendor/lib/hw/com.qti.chi.override.so..."
+            sed 's/ro.boot.flash.locked/ro.camera.notify_nfc/g' "/vendor/lib/hw/com.qti.chi.override.so" > "$MODPATH/system/vendor/lib/hw/com.qti.chi.override.so"
+            set_perm "$MODPATH/system/vendor/lib/hw/com.qti.chi.override.so" 0 0 0644 u:object_r:vendor_file:s0
+            PATCH_APPLIED=true
+        else
+            ui_print "    - Skipping /vendor/lib/hw/com.qti.chi.override.so (no patch needed)."
+        fi
+    fi
+
+    if $PATCH_APPLIED; then
+        ui_print "  - Camera fix and permissions applied successfully."
+    else
+        ui_print "  - Camera patch check complete. No patches were required."
+    fi
+else
+    ui_print "  - Device is not an A52s, skipping fix."
+fi
+EOF
+}
+
+# =============================================================================
+# === 3. MAIN EXECUTION
+# =============================================================================
+
+main() {
+    echo "=============================================="
+    echo "Systemless Module Packager (Modular Design)"
+    echo "=============================================="
+
+    # --- Setup Phase ---
+    find_latest_build
+    calculate_vbmeta_props
+    create_base_module_structure
+
+    # --- Base Module File Generation ---
+    # Create the initial module.prop and installer scripts that will be
+    # appended to by the feature packaging functions.
+    cat <<EOF > "$MODULE_WORK_DIR/module.prop"
 id=$MODULE_ID
 name=$MODULE_NAME
 version=$MODULE_VERSION
@@ -85,37 +255,8 @@ description=$MODULE_DESC
 reboot=true
 EOF
 
-# Create service.sh with our dynamically determined values.
-echo "Creating service.sh for property spoofing..."
-cat <<EOF > "$MODULE_WORK_DIR/service.sh"
+    cat <<'EOF' > "$CUSTOMIZE_SH_PATH"
 #!/system/bin/sh
-# This script is executed in post-fs-data mode by Magisk/KernelSU.
-
-# Wait a few seconds for the boot process to stabilize before setting properties.
-sleep 15
-
-# Forcibly create missing boot properties using dynamically determined values
-# from the build script and other plausible reference values.
-resetprop -n ro.boot.vbmeta.avb_version 1.0
-resetprop -n ro.boot.vbmeta.device_state locked
-resetprop -n ro.boot.vbmeta.digest ${VBMETA_DIGEST}
-resetprop -n ro.boot.vbmeta.hash_alg sha256
-resetprop -n ro.boot.vbmeta.invalidate_on_error yes
-resetprop -n ro.boot.vbmeta.size ${VBMETA_SIZE}
-resetprop -n ro.boot.verifiedbootstate green
-
-# Log that the script has run successfully.
-log -p i -t KernelHelper "Successfully spoofed boot properties."
-EOF
-chmod 755 "$MODULE_WORK_DIR/service.sh"
-
-# Create customize.sh with permission-setting logic.
-echo "Creating customize.sh..."
-cat <<'EOF' > "$MODULE_WORK_DIR/customize.sh"
-#!/system/bin/sh
-# This script is executed by the Magisk/KernelSU installer environment.
-
-# Abort installation if the user tries to flash this in recovery.
 if [ -z "$MODPATH" ]; then
   ui_print "*********************************************************"
   ui_print "! This is a Magisk/KernelSU module, not a recovery ZIP."
@@ -123,63 +264,46 @@ if [ -z "$MODPATH" ]; then
   ui_print "*********************************************************"
   abort
 fi
-
-ui_print "*********************************************************"
-ui_print "*         Installing Kernel Helper Pack for SM7325      *"
-ui_print "*********************************************************"
-ui_print "- Setting permissions..."
-
-# Set permissions for the directory containing all the kernel modules
-set_perm_recursive $MODPATH/system/vendor/lib/modules 0 2000 0755 0644 u:object_r:vendor_file:s0
-ui_print "  - Kernel module permissions set."
-
-# Check for the vendor_modprobe.sh helper and set its permissions
-MODPROBE_HELPER=$MODPATH/system/vendor/bin/vendor_modprobe.sh
-if [ -f "$MODPROBE_HELPER" ]; then
-  set_perm $MODPROBE_HELPER 0 2000 0755 u:object_r:vendor_modinstall-sh_exec:s0
-  ui_print "  - vendor_modprobe.sh permissions set."
-fi
-
-ui_print "- Installation complete."
+ui_print "***********************************"
+ui_print "*  Installing Kernel Helper Pack  *"
+ui_print "***********************************"
 EOF
 
-# Create the standard, minimal META-INF scripts
-echo "Creating standard META-INF scripts..."
-cat <<EOF > "$MODULE_WORK_DIR/META-INF/com/google/android/updater-script"
+    cat <<EOF > "$MODULE_WORK_DIR/META-INF/com/google/android/updater-script"
 # Magisk/KSU stub
 EOF
-cat <<EOF > "$MODULE_WORK_DIR/META-INF/com/google/android/update-binary"
+    cat <<EOF > "$MODULE_WORK_DIR/META-INF/com/google/android/update-binary"
 #!/sbin/sh
-OUTFD=\$2
-ZIPFILE=\$3
-. /data/adb/magisk/util_functions.sh
+if [ -f /data/adb/magisk/util_functions.sh ]; then . /data/adb/magisk/util_functions.sh; else exit 1; fi
 . \$ZIPFILE/customize.sh
 exit 0
 EOF
-chmod 755 "$MODULE_WORK_DIR/META-INF/com/google/android/update-binary"
+    chmod 755 "$MODULE_WORK_DIR/META-INF/com/google/android/update-binary"
 
-# 5. Copy the kernel modules and helper script into the module structure.
-echo "Copying kernel modules..."
-cp -r "$SOURCE_MODULES_DIR"/* "$MODULE_SYSTEM_DIR/vendor/lib/modules/"
+    # --- Feature Packaging Phase ---
+    # Call the core feature functions to populate the module.
+    # To disable a feature, simply comment out its respective line.
+    build_feature_klm_loading
+    build_feature_vbmeta_spoof
+    build_feature_camera_fix
 
-if [ -f "$MODPROBE_SOURCE_SCRIPT" ]; then
-    echo "Copying vendor_modprobe.sh..."
-    mkdir -p "$MODULE_SYSTEM_DIR/vendor/bin"
-    cp "$MODPROBE_SOURCE_SCRIPT" "$MODULE_SYSTEM_DIR/vendor/bin/"
-else
-    echo "WARNING: vendor_modprobe.sh not found in current directory, skipping."
-fi
+    # touch $MODULE_WORK_DIR/skip_mount
 
-# 6. Package everything into a ZIP file.
-echo "Creating flashable ZIP: $MODULE_ZIP_NAME..."
-cd "$MODULE_WORK_DIR"
-zip -r9 "../$MODULE_ZIP_NAME" ./*
-cd ..
+    # Append a final footer to customize.sh
+    echo 'ui_print "- Installation complete."' >> "$CUSTOMIZE_SH_PATH"
 
-# 7. Final cleanup.
-rm -rf "$MODULE_WORK_DIR"
+    # --- Finalization Phase ---
+    echo "Creating flashable ZIP: $MODULE_ZIP_NAME..."
+    cd "$MODULE_WORK_DIR"
+    zip -r9 "../$MODULE_ZIP_NAME" ./* > /dev/null
+    cd ..
+    rm -rf "$MODULE_WORK_DIR"
 
-echo "=============================================="
-echo "Successfully created systemless module:"
-echo "$MODULE_ZIP_NAME"
-echo "=============================================="
+    echo "=============================================="
+    echo "Successfully created systemless module:"
+    echo "$MODULE_ZIP_NAME"
+    echo "=============================================="
+}
+
+# Run the main function
+main


### PR DESCRIPTION
Integrates an automatic camera patch into the helper module.

The generated `customize.sh` now detects A52s devices and systemlessly patches the camera libraries by spoofing the `ro.boot.flash.locked` check.